### PR TITLE
Rename texts.token to texts.url

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -10,7 +10,7 @@ class TextsController < ApplicationController
   end
 
   def show
-    @text = Text.find_by!(token: params[:token])
+    @text = Text.find_by!(url: params[:url])
   end
 
   private

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,22 +1,22 @@
 class Text < ApplicationRecord
-  TOKEN_LENGHT = 3
+  URL_LENGHT = 3
 
-  before_create :set_token
+  before_create :set_url
 
   def to_param
-    token
+    url
   end
 
   private
 
-  def set_token
-    self.token = generate_token
+  def set_url
+    self.url = generate_url
   end
 
-  def generate_token
+  def generate_url
     loop do
-      token = SecureRandom.alphanumeric(TOKEN_LENGHT)
-      break token unless Text.exists?(token: token)
+      url = SecureRandom.alphanumeric(URL_LENGHT)
+      break url unless Text.exists?(url: url)
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
       </div>
 
       <footer class="text-slate-700 pt-6 pb-10 text-sm flex justify-between">
-        <%= link_to "Что это?", text_path(token: 'about') %>
+        <%= link_to "Что это?", text_path(url: 'about') %>
         <span>© 2022</span>
       </footer>
     </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: 'texts#new'
 
-  resources :texts, only: %i[create show], param: :token
+  resources :texts, only: %i[create show], param: :url
 end

--- a/db/migrate/20220329085331_rename_text_token_to_url.rb
+++ b/db/migrate/20220329085331_rename_text_token_to_url.rb
@@ -1,0 +1,5 @@
+class RenameTextTokenToUrl < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :texts, :token, :url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_28_201615) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_29_085331) do
   create_table "texts", force: :cascade do |t|
     t.string "body"
-    t.string "token"
+    t.string "url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["token"], name: "index_texts_on_token", unique: true
+    t.index ["url"], name: "index_texts_on_url", unique: true
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,4 +2,4 @@ readme_path = Rails.root.join('README.md')
 
 content = File.read(readme_path)
 
-Text.create(body: content).update(token: 'about')
+Text.create(body: content).update(url: 'about')

--- a/lib/tasks/telegram_bot.rake
+++ b/lib/tasks/telegram_bot.rake
@@ -24,7 +24,7 @@ namespace :telegram_bot do
     message = ["Последние опубликованные снипеты:"]
 
     message += texts.map do |text|
-      "#{url_base}/#{text.token}\n#{text.body}"
+      "#{url_base}/#{text.url}\n#{text.body}"
     end
 
     message.join("\n" * 2)


### PR DESCRIPTION
`token` is filtered parameter by default by rails. Text token is not seсret parameter and it is inherently part of URL

I suggest renaming this attribute

In rails console before:

```
#<Text:0x000055d419966de0 id: 15, body: "21", token: "[FILTERED]", created_at: Tue, 29 Mar 2022 08:47:49.890421000 UTC +00:00, updated_at: Tue, 29 Mar 2022 08:47:49.952773000 UTC +00:00>
```

After:

```
#<Text:0x0000564a99392c60 id: 15, body: "21", url: "XXE", created_at: Tue, 29 Mar 2022 08:47:49.890421000 UTC +00:00, updated_at: Tue, 29 Mar 2022 08:47:49.952773000 UTC +00:00>
```