### PR TITLE
buttons moved to header

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,8 +13,9 @@
 
   <body class="h-screen bg-slate-900 text-slate-200">
     <main class="h-full max-w-4xl mx-auto pt-10 px-8 box-border flex flex-col">
-      <header class="font-bold mb-6 uppercase text-sm md:text-base">
-        <%= link_to "📝 droptext.ru", root_path %>
+      <header class="font-bold mb-3 uppercase text-sm md:text-base flex flex-wrap justify-between">
+        <%= link_to "📝 droptext.ru", root_path, class: 'mb-3' %>
+        <%= yield :header %>
       </header>
 
       <div class="grow">

--- a/app/views/snippets/show.html.erb
+++ b/app/views/snippets/show.html.erb
@@ -1,12 +1,14 @@
-<div class="relative flex h-full group text-sm md:text-base">
-  <span class="absolute top-3 right-5">
+<% content_for :header do %>
+  <span>
     <%= link_to t('.raw'), {format: 'text'},
-      class: 'btn btn-amber opacity-25 group-hover:opacity-75' %>
+      class: 'btn btn-amber group-hover:opacity-75' %>
     <%= link_to '📋', '', data: {clipboard_text: request.original_url},
-      class: 'js-clipboard btn btn-amber opacity-25 group-hover:opacity-75',
+      class: 'js-clipboard btn btn-amber group-hover:opacity-75',
       title: t('.copy_url') %>
   </span>
+<% end %>
 
+<div class="relative flex h-full group text-sm md:text-base">
   <div class="grow px-5 py-3 bg-slate-700 overflow-x-auto">
     <pre><code class="whitespace-pre-wrap <%= language_class(@snippet) %>"><%= h(@snippet.body) %></code></pre>
   </div>


### PR DESCRIPTION
because on mobile devices they overlap characters in the textarea

ex: https://i2.paste.pics/GS86N.png